### PR TITLE
Update the for and id field attributes with the form field name so yo…

### DIFF
--- a/resources/views/half-stars/component.blade.php
+++ b/resources/views/half-stars/component.blade.php
@@ -42,14 +42,14 @@
             <input
                 type="radio"
                 value="0"
-                id="star-0"
+                id="{{ $field->getName() }}-star-0"
                 class="!hidden peer"
                 @disabled($isDisabled)
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
             >
 
             <label
-                for="star-0"
+                for="{{ $field->getName() }}-star-0"
                 @class([
                     "text-slate-300 peer-checked:text-danger-500",
                     "group-hover:!text-slate-300 peer-hover:!text-danger-500 cursor-pointer" => ! $isDisabled,
@@ -61,7 +61,7 @@
 
         @foreach ($getStarsArray() as $value)
             <label
-                for="star-{{ $value - 0.5 }}"
+                for="{{ $field->getName() }}-star-{{ $value - 0.5 }}"
                 @class([
                     "shrink-0 relative {$halfSizeClass} overflow-hidden {$colorClass} peer-checked:text-slate-300",
                     "{$groupHoverColorClass} peer-hover:!text-slate-300 cursor-pointer" => ! $isDisabled,
@@ -73,7 +73,7 @@
             <input
                 type="radio"
                 value="{{ $value - 0.5 }}"
-                id="star-{{ $value - 0.5 }}"
+                id="{{ $field->getName() }}-star-{{ $value - 0.5 }}"
                 class="!hidden peer"
                 wire:loading.attr="disabled"
                 @disabled($isDisabled)
@@ -81,7 +81,7 @@
             >
 
             <label
-                for="star-{{ $value }}"
+                for="{{ $field->getName() }}-star-{{ $value }}"
                 @class([
                     "shrink-0 relative {$halfSizeClass} overflow-hidden {$colorClass} peer-checked:text-slate-300",
                     "{$groupHoverColorClass} peer-hover:!text-slate-300 cursor-pointer" => ! $isDisabled,
@@ -93,7 +93,7 @@
             <input
                 type="radio"
                 value="{{ $value }}"
-                id="star-{{ $value }}"
+                id="{{ $field->getName() }}-star-{{ $value }}"
                 class="!hidden peer"
                 wire:loading.attr="disabled"
                 @disabled($isDisabled)

--- a/resources/views/simple/component.blade.php
+++ b/resources/views/simple/component.blade.php
@@ -35,14 +35,14 @@
             <input
                 type="radio"
                 value="0"
-                id="star-0"
+                id="{{ $field->getName() }}-star-0"
                 class="!hidden peer"
                 @disabled($isDisabled)
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
             >
 
             <label
-                for="star-0"
+                for="{{ $field->getName() }}-star-0"
                 @class([
                     "text-slate-300 peer-checked:text-danger-500",
                     "group-hover:!text-slate-300 peer-hover:!text-danger-500 cursor-pointer" => ! $isDisabled,
@@ -54,7 +54,7 @@
 
         @foreach ($getStarsArray() as $value)
             <label
-                for="star-{{ $value }}"
+                for="{{ $field->getName() }}-star-{{ $value }}"
                 @class([
                     "{$colorClass} peer-checked:text-slate-300",
                     "{$groupHoverColorClass} peer-hover:!text-slate-300 cursor-pointer" => ! $isDisabled,
@@ -66,7 +66,7 @@
             <input
                 type="radio"
                 value="{{ $value }}"
-                id="star-{{ $value }}"
+                id="{{ $field->getName() }}-star-{{ $value }}"
                 class="!hidden peer"
                 wire:loading.attr="disabled"
                 @disabled($isDisabled)

--- a/src/Components/Rating.php
+++ b/src/Components/Rating.php
@@ -19,4 +19,9 @@ class Rating extends Field
     {
         return $this->getTheme()->getView() . '.component';
     }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
 }


### PR DESCRIPTION
Hi @mokhosh 

First of all thanks, thanks for this package!

I need multiple star rating form fields but that is not possible at the moment because the `for` and `id` attribute are always `star-1` for exmple so you haven the same `for` and `id`'s at different star rating field.

Create a fix where I add the form field name before the `for` and `id` to prevent this.